### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/pr-branch-build.yml
+++ b/.github/workflows/pr-branch-build.yml
@@ -1,20 +1,17 @@
 name: PR Branch Build and Test
 
-on:
-  push:
-    branches-ignore:
-      - master
+on: pull_request
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Build and Test
-      run: |
-        pip install virtualenv
-        make test package
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Build and Test
+        run: |
+          pip install virtualenv
+          make test package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,26 @@
-name: Release
+name: Release Package
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - master
 
 jobs:
   build:
-    if: ${{ github.head_ref }} == "master"
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Publish to PyPi
-      env:
-        TWINE_USERNAME: ${{ secrets.LIFEOMIC_PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.LIFEOMIC_PYPI_TOKEN }}
-      run: |
-        python -m pip install --upgrade pip
-        pip install virtualenv
-        make test package deploy
-    - name: Create Release
-      uses: actions/create-release@latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: false
-        prerelease: false
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Publish to PyPi
+        env:
+          TWINE_USERNAME: ${{ secrets.LIFEOMIC_PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.LIFEOMIC_PYPI_TOKEN }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install virtualenv
+          make test package deploy
+

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import json
 import os
 
 from setuptools import setup, find_packages
@@ -22,11 +21,11 @@ setup(
     description="LifeOmic Python Logging Library.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://lifeomic.github.io/phc-sdk-py",
+    url="https://github.com/lifeomic/logging-py",
     license="MIT",
     author="LifeOmic Development",
     author_email="development@lifeomic.com",
-    packages=find_packages(exclude=("tests")),
+    packages=find_packages(exclude=("tests",)),
     include_package_data=True,
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
With this PR, CI now follows the same build and release pattern @smolster found for the `chatbot-tools-py` project:
- The build and test workflow is run on all PRs
- Package releasing is no longer git tag-based. Now, a release is attempted on every merge to master, but the release will exit early if the current package version has already been published

I also made a couple minor fixes to the `setup.py` file