### PR TITLE
Debug PyPi publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,13 @@ package: venv
 	$(PYTHON) setup.py sdist bdist_wheel
 
 deploy: venv
+	# TODO: remove debug
+	$(info current version == $(VERSION))
+	$(info already published versions == "$(PUBLISHED_VERSIONS)")
+	grep $(VERSION) <<< "$(PUBLISHED_VERSIONS)"
+	# TODO: end debug
 	if [ $(IS_VERSION_PUBLISHED) -eq 0 ]; then \
-	  echo "Versioned $(VERSION) is already published, exiting"; \
+	  echo "Version $(VERSION) is already published, exiting"; \
 	else \
 	  echo "Now publishing version $(VERSION)" && $(PYTHON) -m twine upload dist/*; \
 	fi


### PR DESCRIPTION
The `deploy` step in the Makefile was working on my local machine, but in CI, one shell expression evaluated to an unexpected value, and the deploy step failed. This PR adds debug lines to help figure out what's going on, since Makefile was suppressing the output of the failed command.

I will remove these debug lines as soon as I find out what's going on.