### PR TITLE
Fix the deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ PYTHON := env PYTHONPATH=$(PYTHONPATH) $(VENV)/bin/python
 BLACK := env PYTHONPATH=$(PYTHONPATH) $(VENV)/bin/black
 PIP := $(VENV)/bin/pip3
 VERSION := $(shell python -c "from $(SRC).version import __version__; print(__version__)")
-PUBLISHED_VERSIONS := $(shell $(PIP) index versions $(SRC))
-IS_VERSION_PUBLISHED = $(shell grep -q $(VERSION) <<< "$(PUBLISHED_VERSIONS)"; echo $$?)
 REQUIREMENTS := -r requirements-dev.txt
 
 default: clean test
@@ -38,13 +36,7 @@ package: venv
 	$(PYTHON) setup.py sdist bdist_wheel
 
 deploy: venv
-	# TODO: remove debug
-	$(info output of pip index versions == $(shell $(PIP) index versions $(SRC)))
-	$(info current version == $(VERSION))
-	$(info already published versions == "$(PUBLISHED_VERSIONS)")
-	$(info output of grep == $(shell grep $(VERSION) <<< "$(PUBLISHED_VERSIONS)"; echo $$?))
-	# TODO: end debug
-	if [ $(IS_VERSION_PUBLISHED) -eq 0 ]; then \
+	if [[ "$(shell $(PIP) index versions $(SRC))" == *$(VERSION)* ]]; then \
 	  echo "Version $(VERSION) is already published, exiting"; \
 	else \
 	  echo "Now publishing version $(VERSION)" && $(PYTHON) -m twine upload dist/*; \


### PR DESCRIPTION
For some reason, `pip index versions` works when executed inside a target action, e.g.

```
target
    pip3 index versions <pkg_name>
```

but its not working when evaluated into a makefile variable e.g. `MY_VAR := $(shell pip3 index versions <pkg_name>)`. This PR moves that expression down into the target action.

I'm hoping this is the last fix needed. :crossed_fingers: 